### PR TITLE
Forward full response

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,14 +38,14 @@ export default {
 
 		// Generate the URL to the Meetup API
 		const url = `https://api.meetup.com/${group}/events?photo-host=public&page=${limit}`;
-		
-		const data = await fetch(url);
-		const json = await data.json();
-		
-		return new Response(JSON.stringify(json), {
+
+		const response = await fetch(url);
+
+		return new Response(response.body, {
+			...response,
 			headers: {
+				...response.headers,
 				...CORS_HEADERS,
-				'content-type': 'application/json;charset=UTF-8',
 			},
 		});
 	},


### PR DESCRIPTION
Benefits of this approach:

- Forwards errors correctly, preserving their status codes
- Doesn't buffer the whole response body into memory
- Because we forward the response before we download the body, we end up sending headers (including status codes) faster reducing latency of the proxy

I chose to maintain all of the existing Meetup headers.